### PR TITLE
adding improved informer date range coverage

### DIFF
--- a/inform_opts.go
+++ b/inform_opts.go
@@ -18,10 +18,17 @@ type InformOpts struct {
 	//
 	// Defaults to NamespaceDefault.
 	Namespace string
+
 	// Metadata is a JSON object blob of arbitrary data that will be stored with
 	// the resource. Users should not overwrite or remove anything stored in this
 	// field by Delta.
 	Metadata []byte
+
+	// MaxAttempts is the maximum number of times a resource will be attempted to be
+	// synced.
+	//
+	// Defaults to 10.
+	MaxAttempts int16
 
 	// Tags are an arbitrary list of keywords to add to the resource. They have no
 	// functional behavior and are meant entirely as a user-specified construct

--- a/inform_schedule.go
+++ b/inform_schedule.go
@@ -53,7 +53,7 @@ func (w *controllerInformerScheduler) Work(ctx context.Context, job *river.Job[I
 
 	for _, controller := range controllers {
 		opts := InformOptions{
-			Since: &controller.LastInformTime,
+			After: &controller.LastInformTime,
 		}
 
 		res, err := riverClient.Insert(ctx, InformArgs[kindObject]{

--- a/internal/db/migrations/00001_initial_schema.sql
+++ b/internal/db/migrations/00001_initial_schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE delta_resource(
     attempted_at timestamptz,
     created_at timestamptz NOT NULL DEFAULT NOW(),
     synced_at timestamptz,
+    external_created_at timestamptz,
 
     -- types stored out-of-band
     object_id text NOT NULL,
@@ -60,6 +61,7 @@ CREATE TABLE delta_resource(
 CREATE UNIQUE INDEX delta_resource_object_id_kind_unique ON delta_resource(object_id, kind);
 CREATE INDEX delta_resource_kind ON delta_resource USING btree(kind);
 CREATE INDEX delta_resource_object_id ON delta_resource USING btree(object_id);
+CREATE INDEX delta_resource_external_created_at ON delta_resource USING btree(external_created_at);
 
 -- use Generalized Inverted Index
 CREATE INDEX delta_resource_object_index ON delta_resource USING GIN(object);

--- a/internal/db/sqlc/delta_controller.sql
+++ b/internal/db/sqlc/delta_controller.sql
@@ -31,7 +31,7 @@ WHERE inform_interval > '0'
 ORDER BY last_inform_time ASC;
 -- name: ControllerSetLastInformTime :exec
 UPDATE delta_controller
-SET last_inform_time = now(),
+SET last_inform_time = @last_inform_time,
     updated_at = now()
 WHERE name = @name;
 -- name: ControllerGet :one

--- a/internal/db/sqlc/delta_controller.sql.go
+++ b/internal/db/sqlc/delta_controller.sql.go
@@ -120,12 +120,17 @@ func (q *Queries) ControllerListReady(ctx context.Context) ([]*DeltaController, 
 
 const controllerSetLastInformTime = `-- name: ControllerSetLastInformTime :exec
 UPDATE delta_controller
-SET last_inform_time = now(),
+SET last_inform_time = $1,
     updated_at = now()
-WHERE name = $1
+WHERE name = $2
 `
 
-func (q *Queries) ControllerSetLastInformTime(ctx context.Context, name string) error {
-	_, err := q.db.Exec(ctx, controllerSetLastInformTime, name)
+type ControllerSetLastInformTimeParams struct {
+	LastInformTime time.Time
+	Name           string
+}
+
+func (q *Queries) ControllerSetLastInformTime(ctx context.Context, arg *ControllerSetLastInformTimeParams) error {
+	_, err := q.db.Exec(ctx, controllerSetLastInformTime, arg.LastInformTime, arg.Name)
 	return err
 }

--- a/internal/db/sqlc/models.go
+++ b/internal/db/sqlc/models.go
@@ -76,19 +76,20 @@ type DeltaNamespace struct {
 }
 
 type DeltaResource struct {
-	ID          int64
-	State       DeltaResourceState
-	Attempt     int16
-	MaxAttempts int16
-	AttemptedAt *time.Time
-	CreatedAt   time.Time
-	SyncedAt    *time.Time
-	ObjectID    string
-	Kind        string
-	Namespace   string
-	Object      []byte
-	Hash        []byte
-	Metadata    []byte
-	Tags        []string
-	Errors      [][]byte
+	ID                int64
+	State             DeltaResourceState
+	Attempt           int16
+	MaxAttempts       int16
+	AttemptedAt       *time.Time
+	CreatedAt         time.Time
+	SyncedAt          *time.Time
+	ExternalCreatedAt *time.Time
+	ObjectID          string
+	Kind              string
+	Namespace         string
+	Object            []byte
+	Hash              []byte
+	Metadata          []byte
+	Tags              []string
+	Errors            [][]byte
 }

--- a/namespace.go
+++ b/namespace.go
@@ -26,6 +26,11 @@ type NamespaceConfig struct {
 	// ResourceExpiry is the duration (seconds) after which a previously
 	// synced resource is considered expired.
 	//
+	// This can be used to re-sync resources that may change or update in the
+	// external system that may not be automatically re-informed based on a
+	// creation time After filter. For immutable resources, this should NOT be set
+	// to prevent unnecessary work for objects that will never change.
+	//
 	// If this is set to 0, resources within the namespace will never expire.
 	// Defaults to 0 (resources never expire).
 	ResourceExpiry time.Duration

--- a/resource.go
+++ b/resource.go
@@ -29,9 +29,27 @@ func (r Resource[T]) Kind() string {
 type Object interface {
 	// ID is a string that uniquely identifies the object.
 	ID() string
+
 	// Kind is a string that uniquely identifies the type of resource. This must be
 	// provided on your resource object struct.
 	Kind() string
+}
+
+// ObjectWithCreatedAt is an extra interface that a resource may implement on top
+// of Object to provide a created at time as reported by an external system.
+// It is strongly recommended to implement this interface for all resources.
+//
+// This is important to prevent race conditions where a resource is created after
+// the informer has finished but before the controller has updated its last inform time.
+//
+// If this is not implemented, the current time will be used to track controller inform periods
+// which is subject to Delta potentially excluding resources from being informed.
+type ObjectWithCreatedAt interface {
+	// CreatedAt returns the time the object was created.
+	// This is used to determine the ordering of resources
+	// and ensure periodic informers have 100% coverage of resources from
+	// the controller's previous inform interval.
+	CreatedAt() time.Time
 }
 
 // ObjectWithInformArgs is an extra interface that a resource may implement on top


### PR DESCRIPTION
This PR does a few important things:
- Adds nullable `external_created_at` timestamp to the `delta_resource` table along with an optional interface for Objects to implement to expose a `CreatedAt()` method.
- Renames `Since` InformOpt to `After` and beef up the description of this field.
- Updated informer logic around the `last_inform_time` of a `delta_controller` to respect the last informed resource's `external_created_at` (this ensures 0 gaps in possible races that existed using `time.Now()` )